### PR TITLE
Fix minor scripting problems & make busybox build static

### DIFF
--- a/make-busybox.sh
+++ b/make-busybox.sh
@@ -11,6 +11,9 @@ mkdir $BUILD
 cd busybox-*/ || exit -1
 make -s defconfig
 
+# Make the build static
+sed -i 's/# CONFIG_STATIC is not set/CONFIG_STATIC=y/' .config
+
 # Make and install BusyBox
 make -s CONFIG_PREFIX=$BUILD/busyroot install
 chmod 4755 $BUILD/busyroot/bin/busybox
@@ -31,7 +34,6 @@ mkdir dev sys etc proc mnt mnt/new-root
 # Create the init file.
 mv $BUILD/busyroot/sbin/init $BUILD/busyroot/sbin/init.orig
 cat <<'EOL' > $BUILD/busyroot/sbin/init
-
 #!/bin/busybox sh
 PATH=/bin:/usr/bin:/sbin:/usr/sbin
 NEWDEV="/dev/sdj"

--- a/make-ec2-image.sh
+++ b/make-ec2-image.sh
@@ -37,7 +37,7 @@ $AMIBIN/ec2-upload-bundle -b $EC2_BUCKET -m /tmp/busybox.fs.manifest.xml -a $AWS
 
 #19. Register the AMI.
 
-BUSYBOX_AMI=`$AMIBIN/ec2-register "$EC2_BUCKET/busybox.fs.manifest.xml"  | awk '{print $2}'`
+BUSYBOX_AMI=`$APIBIN/ec2-register "$EC2_BUCKET/busybox.fs.manifest.xml"  | awk '{print $2}'`
 echo "BUSYBOX_AMI: $BUSYBOX_AMI"
 
 #20. Create an EBS volume of the desired size (10G or more) in the desired availability zone.

--- a/make-ec2-image.sh
+++ b/make-ec2-image.sh
@@ -7,8 +7,8 @@ if ! [ -e $BUSYBOX_FS ]; then echo "$BUSYBOX_FS: not found (did you run make-bus
 # default values to be overridden by local configuration
 export EC2_CERT=/path/to/your/cert.pem
 export EC2_PRIVATE_KEY=/path/to/your/pk.pem
-export EC2_BUCKET=”your_bucket”
-export AWS_ACCOUNT_NUMBER=”NNNN-NNNN-NNNN”
+export EC2_BUCKET="your_bucket"
+export AWS_ACCOUNT_NUMBER="NNNN-NNNN-NNNN"
 export AWS_ACCESS_KEY_ID=your_key
 export AWS_SECRET_ACCESS_KEY=your_secret_key
 # override defaults with secret values
@@ -17,25 +17,27 @@ export AWS_SECRET_ACCESS_KEY=your_secret_key
 export AMIBIN=./ec2-ami-tools-*/bin
 export APIBIN=./ec2-api-tools-*/bin
 
-#export JAVA_HOME=/usr/java/default
+export EC2_HOME=$(ls -d ./ec2-api-tools-*)
+
+export JAVA_HOME=/usr/lib/jvm/default-java
 export ARCH=`uname -i`
-export AKI=/vmlinuz
-export ARI=/initrd.img
+# Comment by pndiku: AKI's don't exist for HVM instances
+# export ARI=`curl -s http://169.254.169.254/latest/meta-data/ramdisk-id`
 export INSTANCE_ID=`curl -s http://169.254.169.254/latest/meta-data/instance-id`
 export AVAIL_ZONE=`curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone`
 export SEC_GROUP=`curl -s http://169.254.169.254/latest/meta-data/security-groups`
-export PUB_KEY=`wget -q -O - “http://169.254.169.254/latest/meta-data/public-keys” | awk -F= '{print $2}'`
+export PUB_KEY=`wget -q -O - "http://169.254.169.254/latest/meta-data/public-keys" | awk -F= '{print $2}'`
 
 #17. Bundle the image.
-$AMIBIN/ec2-bundle-image -i $BUSYBOX_FS -d /tmp -k $EC2_PRIVATE_KEY -c $EC2_CERT -u $AWS_ACCOUNT_NUMBER -r $ARCH –kernel $AKI –ramdisk $ARI || exit -1
+$AMIBIN/ec2-bundle-image -i $BUSYBOX_FS -d /tmp -k $EC2_PRIVATE_KEY -c $EC2_CERT -u $AWS_ACCOUNT_NUMBER -r $ARCH  || exit -1
 
 echo "#18. Upload the image."
 
-$AMIBIN/ec2-upload-bundle -b $EC2_BUCKET -m /tmp/busybox.fs.manifest.xml -a $AWS_ACCESS_KEY_ID -s $AWS_SECRET_ACCESS_KEY || exit -1
+$AMIBIN/ec2-upload-bundle -b $EC2_BUCKET -m /tmp/busybox.fs.manifest.xml -a $AWS_ACCESS_KEY -s $AWS_SECRET_KEY || exit -1
 
 #19. Register the AMI.
 
-BUSYBOX_AMI=`$AMIBIN/ec2-register "$EC2_BUCKET/busybox.fs.manifest.xml" | awk '{print $2}'`
+BUSYBOX_AMI=`$AMIBIN/ec2-register "$EC2_BUCKET/busybox.fs.manifest.xml"  | awk '{print $2}'`
 echo "BUSYBOX_AMI: $BUSYBOX_AMI"
 
 #20. Create an EBS volume of the desired size (10G or more) in the desired availability zone.
@@ -43,18 +45,27 @@ echo "BUSYBOX_AMI: $BUSYBOX_AMI"
 VOLUME_ID=`$APIBIN/ec2-create-volume -s 10 -z $AVAIL_ZONE | awk '{print $2}'`
 echo "VOLUME_ID: $VOLUME_ID"
 
+# Comment by pndiku: The "sleep" parameters put below aren't trustworthy
+# A better way to check would be to poll the instance
+
 #21. Attach the volume to the current instance as /dev/sdj.
+echo "Waiting for volume to be created..."
+sleep 30
 
 $APIBIN/ec2-attach-volume $VOLUME_ID -i $INSTANCE_ID -d /dev/sdj || exit -1
 
-#22. Create an EXT3 file system on /dev/sdj.
+#22. Create a partition and an EXT3 file system on /dev/sdj.
+echo "Waiting for volume to be attached..."
+sleep 30
 
-mkfs.ext3 /dev/sdj || exit -1
+# We'll later use a label for mounting
+# Comment by pndiku: HVMs use the xvd terminology, not sd
+mkfs.ext3 /dev/xvdj -L "root" || exit -1
 
 #22. Mount the EBS volume.
 
 mkdir /mnt/ebs_boot || exit -1
-mount /dev/sdj /mnt/ebs_boot || exit -1
+mount /dev/xvdj /mnt/ebs_boot || exit -1
 
 #23. Copy the current AMI to the EBS volume.
 
@@ -62,21 +73,12 @@ rsync -avHx / /mnt/ebs_boot || exit -1
 
 #24. Fix the /etc/fstab file.
 
-cat /mnt/ebs_boot/etc/fstab
-cat <<EOF
- Remove the local file systems.
-/dev/sda1 / ext3 defaults 1 1
-/dev/sdb /mnt ext3 defaults 1 2
-/dev/sda3 swap swap defaults 0 0
-Add the /dev/sdj file system.
-/dev/sdj / ext3 defaults 1 1
+cat > /mnt/ebs_boot/etc/fstab << EOF
+LABEL=root / ext3 defaults 1 1
 EOF
 
-#25. Fix the /etc/inittab file. The cloud AMI’s are normally configured for runlevel 4.
-
-cat /mnt/ebs_boot/etc/inittab
-cat <<EOF
-Edit the following line if necessary:
+#25. Fix the /etc/inittab file. The cloud AMI's are normally configured for runlevel 4.
+cat > /mnt/ebs_boot/etc/inittab <<EOF
 id:4:initdefault:
 EOF
 
@@ -91,11 +93,13 @@ $APIBIN/ec2-detach-volume $VOLUME_ID -i $INSTANCE_ID -d /dev/sdj
 
 #28. Create a new instance running the BusyBox AMI.
 
-BUSYBOX_ID=`$APIBIN/ec2-run-instances $BUSYBOX_AMI -z $AVAIL_ZONE -k $PUB_KEY -g $SEC_GROUP | awk '{print $6}'`
+BUSYBOX_ID=`$APIBIN/ec2-run-instances $BUSYBOX_AMI -z $AVAIL_ZONE -k $PUB_KEY -g $SEC_GROUP | grep INSTANCE | awk '{print $2}'`
 
-#29. Wait until the instance is running…
+echo "Please wait while launching instance"
+sleep 30
+#29. Wait until the instance is running...
 
-$APIBIN/ec2-describe-instances $BUSYBOX_ID
+$APIBIN/ec2-describe-instances $BUSYBOX_ID 
 
 #30. Attach the EBS volume to the BusyBox instance as /dev/sdj.
 
@@ -105,7 +109,7 @@ $APIBIN/ec2-attach-volume $VOLUME_ID -i $BUSYBOX_ID -d /dev/sdj
 
 $APIBIN/ec2-reboot-instances $BUSYBOX_ID
 
-#32. Check the BusyBox instance’s console output to make sure it came up as expected.
+#32. Check the BusyBox instance's console output to make sure it came up as expected.
 
 $APIBIN/ec2-get-console-output $BUSYBOX_ID
 


### PR DESCRIPTION
The `make-ec2-image` script had errors (mainly smart quotes) and one logic bug - in the CAT statements that are for creating the `/etc/inittab` and `/etc/fstab`
